### PR TITLE
Improve blog features and metadata

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,19 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "Joao Pinheiro",
+  "short_name": "Joao Pinheiro",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,24 +26,26 @@ export default function RootLayout({
   return (
     <>
       <html lang="pt-PT" className={`${nunito.variable} ${quicksand.variable}`}>
-        <link
-          rel="apple-touch-icon"
-          sizes="180x180"
-          href="/apple-touch-icon.png"
-        />
-        <link
-          rel="icon"
-          type="image/png"
-          sizes="32x32"
-          href="/favicon-32x32.png"
-        />
-        <link
-          rel="icon"
-          type="image/png"
-          sizes="16x16"
-          href="/favicon-16x16.png"
-        />
-        <link rel="manifest" href="/site.webmanifest" />
+        <head>
+          <link
+            rel="apple-touch-icon"
+            sizes="180x180"
+            href="/apple-touch-icon.png"
+          />
+          <link
+            rel="icon"
+            type="image/png"
+            sizes="32x32"
+            href="/favicon-32x32.png"
+          />
+          <link
+            rel="icon"
+            type="image/png"
+            sizes="16x16"
+            href="/favicon-16x16.png"
+          />
+          <link rel="manifest" href="/site.webmanifest" />
+        </head>
         <body className={`${nunito.variable}`}>{children}</body>
       </html>
     </>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div style={{ textAlign: "center", marginTop: "2rem" }}>
+      <h2>Page not found</h2>
+      <p>
+        <Link href="/">Return home</Link>
+      </p>
+    </div>
+  );
+}

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -1,17 +1,16 @@
 // src/app/post/[id]/page.tsx
 "use client";
 
-import { use } from "react";
 import { useRouter } from "next/navigation";
 import postsData from "@/data/posts.json";
 import styles from "@/styles/postPage.module.css";
 
-interface Params {
-  id: string;
-}
-
-export default function PostPage({ params }: { params: Promise<Params> }) {
-  const { id } = use(params);
+export default function PostPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const { id } = params;
   const router = useRouter();
   const post = postsData.find((p) => p._id === id);
 

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -29,20 +29,24 @@ export default function PostList() {
 
   return (
     <section className={styles.container}>
-      <div className={styles.gridContainer}>
-        {filtered.map((post) => (
-          <Link key={post._id} href={`/post/${post._id}`} className={styles.card}>
-            <div>
-              <h3 className={styles.title}>{post.title}</h3>
-              <p className={styles.excerpt}>{post.content.slice(0, 100)}...</p>
-            </div>
-            <div className={styles.meta}>
-              <div className={styles.category}>{post.categories[0]}</div>
-              <div className={styles.date}>{post.date}</div>
-            </div>
-          </Link>
-        ))}
-      </div>
+      {filtered.length === 0 ? (
+        <p className={styles.noPosts}>No posts found</p>
+      ) : (
+        <div className={styles.gridContainer}>
+          {filtered.map((post) => (
+            <Link key={post._id} href={`/post/${post._id}`} className={styles.card}>
+              <div>
+                <h3 className={styles.title}>{post.title}</h3>
+                <p className={styles.excerpt}>{post.content.slice(0, 100)}...</p>
+              </div>
+              <div className={styles.meta}>
+                <div className={styles.category}>{post.categories[0]}</div>
+                <div className={styles.date}>{post.date}</div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
     </section>
   );
 }

--- a/src/styles/postList.module.css
+++ b/src/styles/postList.module.css
@@ -70,3 +70,10 @@
 .category {
   text-transform: capitalize;
 }
+
+.noPosts {
+  text-align: center;
+  font-size: 1.25rem;
+  margin: 2rem 0;
+  color: var(--color-muted);
+}


### PR DESCRIPTION
## Summary
- wrap favicon links with `<head>` in `RootLayout`
- simplify `PostPage` params handling
- show a friendly message when filters match no posts
- style the empty post list message
- update PWA manifest details
- add a basic 404 page
- fix navigation link on not-found page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68507f286b98832e959ae0be9a2c491d